### PR TITLE
update rustbook

### DIFF
--- a/script/install_rustbook.sh
+++ b/script/install_rustbook.sh
@@ -5,7 +5,7 @@ export RUSTBOOK=$ROOT/rustbook; echo "INFO:RUSTBOOK: $RUSTBOOK"
 
 git clone https://github.com/steveklabnik/rustbook $RUSTBOOK
 cd $RUSTBOOK
-git checkout eb96cc8
+git checkout 6718cda7fea65d830f6271bd4ae1a66ca5dbc81c
 cargo build --release
 cd $ROOT
 


### PR DESCRIPTION
Текущая используемая версия rustbook'a уже не собирается ночными версиями Rust'a.
Сейчас в репозитории Стива код rustbook'a соответствует коду rustbook'a в репозитории rust'a. 
Ошибка с не верным формированием ссылок исправлена

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/kgv/rust_book_ru/193)

<!-- Reviewable:end -->
