### PR TITLE
Оглавление в конвертированных версиях книги

### DIFF
--- a/script/convert.sh
+++ b/script/convert.sh
@@ -17,12 +17,10 @@ ebook-convert \
     --language="ru" \
     --book-producer="" \
     --publisher="" \
-    --chapter="descendant-or-self::*[contains(concat(' ', normalize-space(@class), ' '), ' book-chapter ')]" \
+    --chapter="//h:h1[@class='title']" \
     --chapter-mark="pagebreak" \
     --page-breaks-before="/" \
-    --level1-toc="descendant-or-self::*[contains(concat(' ', normalize-space(@class), ' '), ' book-chapter-1 ')]" \
-    --level2-toc="descendant-or-self::*[contains(concat(' ', normalize-space(@class), ' '), ' book-chapter-2 ')]" \
-    --level3-toc="descendant-or-self::*[contains(concat(' ', normalize-space(@class), ' '), ' book-chapter-3 ')]" \
+    --level1-toc="//h:h1[@class='title']" \
     --no-chapters-in-toc \
     --max-levels="1" \
     --breadth-first \
@@ -37,12 +35,10 @@ ebook-convert \
     --language="ru" \
     --book-producer="" \
     --publisher="" \
-    --chapter="descendant-or-self::*[contains(concat(' ', normalize-space(@class), ' '), ' book-chapter ')]" \
+    --chapter="//h:h1[@class='title']" \
     --chapter-mark="pagebreak" \
     --page-breaks-before="/" \
-    --level1-toc="descendant-or-self::*[contains(concat(' ', normalize-space(@class), ' '), ' book-chapter-1 ')]" \
-    --level2-toc="descendant-or-self::*[contains(concat(' ', normalize-space(@class), ' '), ' book-chapter-2 ')]" \
-    --level3-toc="descendant-or-self::*[contains(concat(' ', normalize-space(@class), ' '), ' book-chapter-3 ')]" \
+    --level1-toc="//h:h1[@class='title']" \
     --no-chapters-in-toc \
     --max-levels="1" \
     --breadth-first
@@ -56,12 +52,10 @@ ebook-convert \
     --language="ru" \
     --book-producer="" \
     --publisher="" \
-    --chapter="descendant-or-self::*[contains(concat(' ', normalize-space(@class), ' '), ' book-chapter ')]" \
+    --chapter="//h:h1[@class='title']" \
     --chapter-mark="pagebreak" \
     --page-breaks-before="/" \
-    --level1-toc="descendant-or-self::*[contains(concat(' ', normalize-space(@class), ' '), ' book-chapter-1 ')]" \
-    --level2-toc="descendant-or-self::*[contains(concat(' ', normalize-space(@class), ' '), ' book-chapter-2 ')]" \
-    --level3-toc="descendant-or-self::*[contains(concat(' ', normalize-space(@class), ' '), ' book-chapter-3 ')]" \
+    --level1-toc="//h:h1[@class='title']" \
     --no-chapters-in-toc \
     --max-levels="1" \
     --breadth-first \


### PR DESCRIPTION
Изменено получение информации о главах при конвертации. В оглавлении отображаются все главы, но не отображаются номера глав и нет группировки глав (такого, как в содержании на сайте).

Логика формирования: находятся все теги h1 с классом "title" - этот класс проставляется всем заголовкам (первая строка в исходных файлах, начинается с `%`).
До этого calibre не находил необходимые теги и, по всей видимости, брал 50 ссылок из оглавления в README.html

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/kgv/rust_book_ru/195)

<!-- Reviewable:end -->
